### PR TITLE
Replace ancient FSF address with the canonical URL.

### DIFF
--- a/lib/braiding.cpp
+++ b/lib/braiding.cpp
@@ -14,8 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Braiding; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+    along with Braiding.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /*

--- a/lib/braiding.h
+++ b/lib/braiding.h
@@ -14,8 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Braiding; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+    along with Braiding.  If not, see <https://www.gnu.org/licenses/>.
 */
 /*
     braiding.h,  v 1.0.   04/10/2004

--- a/lib/cbraid.cpp
+++ b/lib/cbraid.cpp
@@ -14,8 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with CBraid; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+    along with CBraid.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 

--- a/lib/cbraid.h
+++ b/lib/cbraid.h
@@ -14,8 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with CBraid; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+    along with CBraid.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 

--- a/lib/cbraid_implementation.h
+++ b/lib/cbraid_implementation.h
@@ -14,8 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with CBraid; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+    along with CBraid.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 

--- a/lib/cbraid_interface.h
+++ b/lib/cbraid_interface.h
@@ -14,8 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with CBraid; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+    along with CBraid.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 


### PR DESCRIPTION
The FSF address in the current sources is more than a decade out of date.  Replace it with the URL as given in the GPL 3 license text.